### PR TITLE
Add `auto_impl(keep_default_for(...))` attribute

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ nightly = ["proc-macro2/nightly"]
 [dependencies]
 proc-macro2 = { version = "0.4.6" }
 quote = "0.6.3"
-syn = { version = "0.14.4", features = ["full"] }
+syn = { version = "0.14.4", features = ["full", "visit-mut"] }
 
 [dev-dependencies]
 build-plan = "0.1.1"

--- a/examples/keep_default_for.rs
+++ b/examples/keep_default_for.rs
@@ -1,0 +1,50 @@
+//! Example to demonstrate how to use the `keep_default_for` attribute.
+//!
+//! The generated `impl` blocks generate an item for each trait item by
+//! default. This means that default methods in traits are also implemented via
+//! the proxy type. Sometimes, this is not what you want. One special case is
+//! when the default method has where bounds that don't apply to the proxy
+//! type.
+use auto_impl::auto_impl;
+
+
+#[auto_impl(&, Box)]
+trait Foo {
+    fn required(&self) -> String;
+
+    // The generated impl for `&T` will not override this method.
+    #[auto_impl(keep_default_for(&))]
+    fn provided(&self) {
+        println!("Hello {}", self.required());
+    }
+}
+
+impl Foo for String {
+    fn required(&self) -> String {
+        self.clone()
+    }
+
+    fn provided(&self) {
+        println!("привет {}", self);
+    }
+}
+
+fn test_foo(x: impl Foo) {
+    x.provided();
+}
+
+fn main() {
+    let s = String::from("Peter");
+
+    // Output: "привет Peter", because `String` has overwritten the default
+    // method.
+    test_foo(s.clone());
+
+    // Output: "Hello Peter", because the method is not overwritten for the
+    // `&T` impl block.
+    test_foo(&s);
+
+    // Output: "привет Peter", because the `Box<T>` impl overwrites the method
+    // by default, if you don't specify `keep_default_for`.
+    test_foo(Box::new(s));
+}

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -1,0 +1,113 @@
+use proc_macro2::{Delimiter, TokenTree};
+use syn::{
+    Attribute, TraitItemMethod,
+    visit_mut::{VisitMut, visit_item_trait_mut},
+};
+
+use crate::{
+    diag::{DiagnosticExt, SpanExt},
+    proxy::{parse_types, ProxyType},
+    spanned::Spanned
+};
+
+
+
+/// Removes all `#[auto_impl]` attributes that are attached to methods of the
+/// given trait.
+crate fn remove_our_attrs(trait_def: &mut syn::ItemTrait) {
+    struct AttrRemover;
+    impl VisitMut for AttrRemover {
+        fn visit_trait_item_method_mut(&mut self, m: &mut TraitItemMethod) {
+            m.attrs.retain(|a| !is_our_attr(a));
+        }
+    }
+
+    visit_item_trait_mut(&mut AttrRemover, trait_def);
+}
+
+/// Checks if the given attribute is "our" attribute. That means that it's path
+/// is `auto_impl`.
+crate fn is_our_attr(attr: &Attribute) -> bool {
+    attr.path.segments.len() == 1
+        && attr.path.segments.iter().next().map(|seg| {
+            seg.ident == "auto_impl" && seg.arguments.is_empty()
+        }).unwrap()
+}
+
+/// Tries to parse the given attribute as one of our own `auto_impl`
+/// attributes. If it's invalid, an error is emitted and `Err(())` is returned.
+/// You have to make sure that `attr` is one of our attrs with `is_our_attr`
+/// before calling this function!
+crate fn parse_our_attr(attr: &Attribute) -> Result<OurAttr, ()> {
+    assert!(is_our_attr(attr));
+
+    let tokens = attr.tts.clone().into_iter().collect::<Vec<_>>();
+    let body = match &*tokens {
+        [TokenTree::Group(g)] => g.stream(),
+        _ => {
+            return attr.tts.span()
+                .err(format!("expected single group delimitted by`()`, found '{:?}'", tokens))
+                .emit_with_attr_note();
+        }
+    };
+
+    let mut it = body.clone().into_iter();
+
+    let name = match it.next() {
+        Some(TokenTree::Ident(x)) => x,
+        Some(other) => {
+            return Spanned::span(&other)
+                .err(format!("expected ident, found '{}'", other))
+                .emit_with_attr_note();
+        }
+        None => {
+            return attr.tts.span()
+                .err("expected ident, found nothing")
+                .emit_with_attr_note();
+        }
+    };
+
+    let params = match it.next() {
+        Some(TokenTree::Group(ref g)) if g.delimiter() == Delimiter::Parenthesis => {
+            g.stream()
+        }
+        Some(other) => {
+            let msg = format!(
+                "expected arguments for '{}' in parenthesis `()`, found `{}`",
+                name,
+                other,
+            );
+            return Spanned::span(&other)
+                .err(msg)
+                .emit_with_attr_note();
+        }
+        None => {
+            let msg = format!(
+                "expected arguments for '{}' in parenthesis `()`, found nothing",
+                name,
+            );
+            return body.span()
+                .err(msg)
+                .emit_with_attr_note();
+        }
+    };
+
+    let out = match () {
+        () if name == "keep_default_for" => {
+            let proxy_types = parse_types(params.into())?;
+            OurAttr::KeepDefaultFor(proxy_types)
+        }
+        _ => {
+            return Spanned::span(&name)
+                .err(format!("invalid attribute '{}'", name))
+                .emit_with_attr_note();
+        }
+    };
+
+    Ok(out)
+}
+
+#[derive(Clone, PartialEq, Debug)]
+crate enum OurAttr {
+    KeepDefaultFor(Vec<ProxyType>),
+}

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -20,7 +20,7 @@ use crate::{
 crate fn gen_impls(
     proxy_types: &[ProxyType],
     trait_def: &syn::ItemTrait,
-) -> Result<::proc_macro::TokenStream, ()> {
+) -> Result<TokenStream2, ()> {
     let mut tokens = TokenStream2::new();
 
     let (proxy_ty_param, proxy_lt_param) = find_suitable_param_names(trait_def);
@@ -35,7 +35,7 @@ crate fn gen_impls(
         });
     }
 
-    Ok(tokens.into())
+    Ok(tokens)
 }
 
 /// Generates the header of the impl of the given trait for the given proxy

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -8,6 +8,7 @@ use syn::{
 
 use crate::{
     analyze::find_suitable_param_names,
+    attr::{OurAttr, is_our_attr, parse_our_attr},
     diag::{DiagnosticExt, SpanExt},
     proxy::ProxyType,
     spanned::Spanned
@@ -403,6 +404,22 @@ fn gen_method_item(
     trait_def: &ItemTrait,
     proxy_ty_param: &Ident,
 ) -> Result<TokenStream2, ()> {
+    // If this method has a `#[auto_impl(keep_default_for(...))]` attribute for
+    // the given proxy type, we don't generate anything for this impl block.
+    if should_keep_default_for(item, proxy_type)? {
+        if item.default.is_some() {
+            return Ok(TokenStream2::new());
+        } else {
+            return item.sig.span()
+                .err(format!(
+                    "the method `{}` has the attribute `keep_default_for` but is not a default \
+                        method (no body is provided)",
+                    item.sig.ident,
+                ))
+                .emit_with_attr_note();
+        }
+    }
+
     // Determine the kind of the method, determined by the self type.
     let sig = &item.sig;
     let self_arg = SelfType::from_sig(sig);
@@ -590,4 +607,34 @@ fn get_arg_list<'a>(inputs: impl Iterator<Item = &'a FnArg>) -> Result<TokenStre
     }
 
     Ok(args)
+}
+
+/// Checks if the given method has the attribute `#[auto_impl(keep_default_for(...))]`
+/// and if it contains the given proxy type.
+fn should_keep_default_for(m: &TraitItemMethod, proxy_type: &ProxyType) -> Result<bool, ()> {
+    // Get an iterator of just the attribute we are interested in.
+    let mut it = m.attrs.iter()
+        .filter(|attr| is_our_attr(attr))
+        .map(|attr| parse_our_attr(&attr));
+
+    // Check the first (and hopefully only) `keep_default_for` attribute.
+    let out = match it.next() {
+        Some(attr) => {
+            // Check if the attribute lists the given proxy type.
+            let OurAttr::KeepDefaultFor(proxy_types) = attr?;
+            proxy_types.contains(proxy_type)
+        }
+
+        // If there is no such attribute, we return `false`
+        None => false,
+    };
+
+    // Check if there is another such attribute (which we disallow)
+    if it.next().is_some() {
+        return m.sig.span()
+            .err("found two `keep_default_for` attributes on one method")
+            .emit_with_attr_note();
+    }
+
+    Ok(out)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,12 +9,10 @@ extern crate quote;
 
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
-use syn::{
-    TraitItemMethod,
-    visit_mut::{VisitMut, visit_item_trait_mut},
-};
+use quote::ToTokens;
 
 mod analyze;
+mod attr;
 mod diag;
 mod gen;
 mod proxy;
@@ -29,69 +27,58 @@ use crate::{
 /// See crate documentation for more information.
 #[proc_macro_attribute]
 pub fn auto_impl(args: TokenStream, input: TokenStream) -> TokenStream {
-    // We use the closure trick to catch errors until the `catch` syntax is
-    // available. If an error occurs, we won't modify or add any tokens.
-    let result = || -> Result<TokenStream, ()> {
-        // Try to parse the token stream from the attribute to get a list of
-        // proxy types.
-        let proxy_types = proxy::parse_types(args)?;
+    // Try to parse the token stream from the attribute to get a list of proxy
+    // types.
+    let proxy_types = proxy::parse_types(args);
 
-        // Try to parse the item the `#[auto_impl]` attribute was applied to as
-        // trait. Unfortunately, `parse()` consume the token stream, so we have
-        // to clone it.
-        match syn::parse::<syn::ItemTrait>(input.clone()) {
-            // The attribute was applied to a valid trait. Now it's time to
-            // execute the main step: generate a token stream which contains an
-            // impl of the trait for each proxy type.
-            Ok(mut trait_def) => {
-                let generated = gen::gen_impls(&proxy_types, &trait_def)?;
+    // Try to parse the item the `#[auto_impl]` attribute was applied to as
+    // trait. Unfortunately, `parse()` consume the token stream, so we have to
+    // clone it.
+    match syn::parse::<syn::ItemTrait>(input.clone()) {
+        // The attribute was applied to a valid trait. Now it's time to execute
+        // the main step: generate a token stream which contains an impl of the
+        // trait for each proxy type.
+        Ok(mut trait_def) => {
+            let generated = proxy_types.and_then(|proxy_types| {
+                gen::gen_impls(&proxy_types, &trait_def)
+            });
 
-                // Before returning the trait definition, we have to remove all
-                // `#[auto_impl(...)]` attributes on any methods.
-                remove_our_attrs(&mut trait_def);
+            // Before returning the trait definition, we have to remove all
+            // `#[auto_impl(...)]` attributes on all methods.
+            attr::remove_our_attrs(&mut trait_def);
 
-                Ok(quote! { #trait_def #generated }.into())
-            },
-
-            // If the token stream could not be parsed as trait, this most
-            // likely means that the attribute was applied to a non-trait item.
-            // Even if the trait definition was syntactically incorrect, the
-            // compiler usually does some kind of error recovery to proceed. We
-            // get the recovered tokens.
-            Err(e) => {
-                // We have to take the detour through TokenStream2 to get a
-                // good span for the error.
-                TokenStream2::from(input.clone()).span()
-                    .err("couldn't parse trait item")
-                    .note(e.to_string())
-                    .note("the #[auto_impl] attribute can only be applied to traits!")
-                    .emit();
-
-                Err(())
+            match generated {
+                // No errors at all => output the trait and our generated impls
+                Ok(generated) => quote! { #trait_def #generated }.into(),
+                Err(_) => {
+                    // We combine the token stream of the modified trait
+                    // definition with the generated errors (which are tokens
+                    // on stable due to the `compile_error!` hack).
+                    vec![
+                        TokenStream::from(trait_def.into_token_stream()),
+                        diag::error_tokens()
+                    ].into_iter().collect()
+                }
             }
-        }
-    }();
+        },
 
-    // If everything went well, we just return the new token stream. If an
-    // error occured, we combine the original token stream with the generated
-    // errors (which are tokens on stable due to the `compile_error!` hack).
-    match result {
-        Ok(tokens) => tokens,
-        Err(_) => vec![input, diag::error_tokens()].into_iter().collect(),
-    }
-}
+        // If the token stream could not be parsed as trait, this most
+        // likely means that the attribute was applied to a non-trait item.
+        // Even if the trait definition was syntactically incorrect, the
+        // compiler usually does some kind of error recovery to proceed. We
+        // get the recovered tokens.
+        Err(e) => {
+            // We have to take the detour through TokenStream2 to get a
+            // good span for the error.
+            TokenStream2::from(input.clone()).span()
+                .err("couldn't parse trait item")
+                .note(e.to_string())
+                .note("the #[auto_impl] attribute can only be applied to traits!")
+                .emit();
 
-/// Removes all `#[auto_impl]` attributes that are attached to methods of the
-/// given trait.
-fn remove_our_attrs(trait_def: &mut syn::ItemTrait) {
-    struct AttrRemover;
-    impl VisitMut for AttrRemover {
-        fn visit_trait_item_method_mut(&mut self, m: &mut TraitItemMethod) {
-            m.attrs.retain(|a| !a.path.segments.iter().all(|seg| {
-                seg.ident == "auto_impl" && seg.arguments.is_empty()
-            }));
+            // We combine the original token stream with the generated errors
+            // (which are tokens on stable due to the `compile_error!` hack).
+            vec![input, diag::error_tokens()].into_iter().collect()
         }
     }
-
-    visit_item_trait_mut(&mut AttrRemover, trait_def);
 }

--- a/tests/compile-fail/keep_default_for_on_assoc_type.rs
+++ b/tests/compile-fail/keep_default_for_on_assoc_type.rs
@@ -1,0 +1,8 @@
+use auto_impl::auto_impl;
+
+
+#[auto_impl(&)]
+trait Foo {
+    #[auto_impl(keep_default_for(&))]
+    type Foo;
+}

--- a/tests/compile-fail/keep_default_for_on_required_method.rs
+++ b/tests/compile-fail/keep_default_for_on_required_method.rs
@@ -1,0 +1,8 @@
+use auto_impl::auto_impl;
+
+
+#[auto_impl(&)]
+trait Foo {
+    #[auto_impl(keep_default_for(&))]
+    fn required(&self);
+}

--- a/tests/compile-fail/method_attr_invalid.rs
+++ b/tests/compile-fail/method_attr_invalid.rs
@@ -1,0 +1,8 @@
+use auto_impl::auto_impl;
+
+
+#[auto_impl(&)]
+trait Foo {
+    #[auto_impl(ferris_for_life)]
+    fn a(&self);
+}

--- a/tests/compile-pass/keep_default_for_simple.rs
+++ b/tests/compile-pass/keep_default_for_simple.rs
@@ -1,0 +1,10 @@
+use auto_impl::auto_impl;
+
+
+#[auto_impl(&)]
+trait Foo {
+    fn required(&self);
+
+    #[auto_impl(keep_default_for(&))]
+    fn provided(&self) {}
+}

--- a/tests/compile-pass/keep_default_for_with_where_bounds.rs
+++ b/tests/compile-pass/keep_default_for_with_where_bounds.rs
@@ -1,0 +1,10 @@
+use auto_impl::auto_impl;
+
+
+#[auto_impl(&)]
+trait Foo {
+    fn required(&self);
+
+    #[auto_impl(keep_default_for(&))]
+    fn provided(&self) where Self: Clone {}
+}


### PR DESCRIPTION
Closes #10 

This lays the foundation for having all kinds of parameters we can interpret. And `keep_default_for` works as specified in #10.

The changes in `lib.rs` aren't actually that big, I just moved code around which changed indentation.

I think after this PR, it should be easy to get some more people working on this crate. I will mail you in the next couple of days about this topic :)