### PR TITLE
Update `syn` to 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ nightly = ["proc-macro2/nightly"]
 [dependencies]
 proc-macro2 = { version = "0.4.6" }
 quote = "0.6.3"
-syn = { version = "0.14.4", features = ["full", "visit-mut"] }
+syn = { version = "0.15", features = ["full", "visit", "visit-mut"] }
 
 [dev-dependencies]
 build-plan = "0.1.1"

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -3,7 +3,6 @@ use std::collections::HashSet;
 use proc_macro2::Span as Span2;
 use syn::{
     Ident, ItemTrait, Lifetime, Block,
-    token::Apostrophe,
     visit::{Visit, visit_item_trait},
 };
 
@@ -89,7 +88,7 @@ crate fn find_suitable_param_names(trait_def: &ItemTrait) -> (Ident, Lifetime) {
         .find(|i| !visitor.lt_names.contains(i))
         .unwrap_or_else(|| Ident::new(PROXY_LT_PARAM_NAME, param_span()));
     let lt = Lifetime {
-        apostrophe: Apostrophe::new(param_span()),
+        apostrophe: param_span(),
         ident: lt_name,
     };
 


### PR DESCRIPTION
The update was fairly smooth, hence the small PR. Strangely enough, the `visit` feature in Cargom.toml was not necessary in 0.14 despite us using the `visit` module :confused: 

I also locally updated rustc (`rustc 1.30.0-nightly (a8c11d216 2018-09-06)`) and all dependencies and it still compiles, so that's good.