### PR TITLE
Fix method generation with `self` receiver for `FnMut` proxy type

### DIFF
--- a/src/gen.rs
+++ b/src/gen.rs
@@ -470,7 +470,7 @@ fn gen_method_item(
     let body = match self_arg {
         // Fn proxy types get a special treatment
         _ if proxy_type.is_fn() => {
-            quote! { self(#args) }
+            quote! { ({self})(#args) }
         }
 
         // No receiver

--- a/tests/compile-pass/value_self_for_fn_mut.rs
+++ b/tests/compile-pass/value_self_for_fn_mut.rs
@@ -3,8 +3,7 @@ use auto_impl::auto_impl;
 
 #[auto_impl(FnMut)]
 trait Foo {
-    // TODO: this `mut` shouldn't be possible (see #23)
-    fn execute(mut self);
+    fn execute(self);
 }
 
 fn foo(_: impl Foo) {}


### PR DESCRIPTION
Fixes #23 

I just did this myself now: the diff is really small so maybe not even satisfying for beginners trying to help out. And it is a bug that I want to have fixed ASAP.

In the coming days, I will rewrite the README and docs. After that we can think about finally releasing all this work ^_^