### PR TITLE
Use explicit `T::foo(self, args..)` calls in generated methods

### DIFF
--- a/src/gen.rs
+++ b/src/gen.rs
@@ -482,14 +482,14 @@ fn gen_method_item(
         // Receiver `self` (by value)
         SelfType::Value => {
             // The proxy type is a Box.
-            quote! { (*self).#name #generic_types(#args) }
+            quote! { #proxy_ty_param::#name #generic_types(*self, #args) }
         }
 
         // `&self` or `&mut self` receiver
         SelfType::Ref | SelfType::Mut => {
             // The proxy type could be anything in the `Ref` case, and `&mut`
             // or Box in the `Mut` case.
-            quote! { (*self).#name #generic_types(#args) }
+            quote! { #proxy_ty_param::#name #generic_types(self, #args) }
         }
     };
 

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -494,7 +494,6 @@ fn gen_method_item(
     };
 
     // Combine body with signature
-    // TODO: maybe add `#[inline]`?
     Ok(quote! { #sig { #body }})
 }
 

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -466,7 +466,7 @@ fn gen_method_item(
 
     // Generate the body of the function. This mainly depends on the self type,
     // but also on the proxy type.
-    let name = &sig.ident;
+    let fn_name = &sig.ident;
     let body = match self_arg {
         // Fn proxy types get a special treatment
         _ if proxy_type.is_fn() => {
@@ -476,20 +476,20 @@ fn gen_method_item(
         // No receiver
         SelfType::None => {
             // The proxy type is a reference, smartpointer or Box.
-            quote! { #proxy_ty_param::#name #generic_types(#args) }
+            quote! { #proxy_ty_param::#fn_name #generic_types(#args) }
         }
 
         // Receiver `self` (by value)
         SelfType::Value => {
             // The proxy type is a Box.
-            quote! { #proxy_ty_param::#name #generic_types(*self, #args) }
+            quote! { #proxy_ty_param::#fn_name #generic_types(*self, #args) }
         }
 
         // `&self` or `&mut self` receiver
         SelfType::Ref | SelfType::Mut => {
             // The proxy type could be anything in the `Ref` case, and `&mut`
             // or Box in the `Mut` case.
-            quote! { #proxy_ty_param::#name #generic_types(self, #args) }
+            quote! { #proxy_ty_param::#fn_name #generic_types(self, #args) }
         }
     };
 

--- a/tests/compile-pass/method_name_shadowing.rs
+++ b/tests/compile-pass/method_name_shadowing.rs
@@ -1,0 +1,26 @@
+use auto_impl::auto_impl;
+
+trait AllExt {
+    fn foo(&self, _: i32);
+}
+
+impl<T> AllExt for T {
+    fn foo(&self, _: i32) {}
+}
+
+// This will expand to:
+//
+//     impl<T: Foo> Foo for &T {
+//         fn foo(&self, _x: bool) {
+//             T::foo(self, _x)
+//         }
+//     }
+//
+// With this test we want to make sure, that the call `T::foo` is always
+// unambiguous. Luckily, Rust is nice here. And if we only know `T: Foo`, then
+// other global functions are not even considered. Having a test for this
+// doesn't hurt though.
+#[auto_impl(&)]
+trait Foo {
+    fn foo(&self, _x: bool);
+}


### PR DESCRIPTION
We briefly discussed that in #19 

Also: a test and two minor cleanup commits.