### PR TITLE
Use lifetime elision in impl headers for generated impls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,9 @@ matrix:
         - cargo test --verbose || travis_terminate 1
     - name: "Build on beta"
       rust: beta
-      script: cargo build --verbose
+      script:
+        - cargo build --verbose
+        - cargo build --verbose --examples
 
 env:
   global:

--- a/examples/names.rs
+++ b/examples/names.rs
@@ -1,15 +1,15 @@
-//! Example to demonstrate how `auto_impl` chooses a name for the type and
-//! lifetime parameter.
+//! Example to demonstrate how `auto_impl` chooses a name for the type
+//! parameter.
 //!
 //! For documentation and compiler errors it would be nice to have very simple
-//! names for type and lifetime parameters:
+//! names for the type parameter:
 //!
 //! ```rust
 //! // not nice
-//! impl<'auto_impl_lifetime, AutoImplT> Foo for &'auto_impl_lifetime AutoImplT { ...}
+//! impl<AutoImplT> Foo for &AutoImplT { ...}
 //!
 //! // better
-//! impl<'a, T> Foo for &'a T { ... }
+//! impl<T> Foo for &T { ... }
 //! ```
 //!
 //! `auto_impl` tries the full alphabet, picking a name that is not yet taken.
@@ -18,13 +18,11 @@
 //! in the trait def -- apart from names only appearing in the body of provided
 //! methods.
 //!
-//! In the trait below, a bunch of names are already "taken":
-//! - type names: T--Z and A--G (H is not taken, because it only appear in the
-//!   default method body)
-//! - lifetime names: 'a--'c
+//! In the trait below, a bunch of type names are already "taken": T--Z and
+//! A--H. Thus, the name `I` will be used.
 //!
-//! Thus, the names `H` and `'d` are used. Run `cargo expand --example names`
-//! to see the output.
+//! Thus, the name `H` is used. Run `cargo expand --example names` to see the
+//! output.
 
 
 // This code is really ugly on purpose...
@@ -45,12 +43,12 @@ struct G<T>(Vec<T>);
 struct H {}
 
 #[auto_impl(&)]
-trait U<'a, V> {
+trait U<'a, T, V> {
     const W: Option<Box<&'static X>>;
 
     type Y: Z;
 
-    fn A<'b, 'c>(&self, B: C, D: E<&[F; 1]>) -> G<fn((H,))> {
+    fn A(&self, B: C, D: E<&[F; 1]>) -> G<fn((H,))> {
         let H = ();
         unimplemented!()
     }


### PR DESCRIPTION
Fixes #22 

Said feature was finally stabilized in Rust 2015 as well and should be in the next nightly. This change makes the generated impls simpler to read (in the docs). However, this PR bumps the minimal Rust version required to use this crate. However, I think this is not a huge problem since we bump the minimum Rust version with the next release anyway. 

Maybe we can still sneak this in for the 0.3 release.

Additionally, I made Travis compile the examples on beta as well. This is unrelated, but I'm bad at atomic PRs :P 

But regarding Travis, I noticed something: we test all our examples and tests with Rust 2018. But it might be useful to also test them all compiled as Rust 2015? In particular in this situation where a feature was stabilized in Rust 2018 for some time already but is stabilized in Rust 2015 only later. However, I don't think the idea behind editions is that we all start testing all our crates for all editions (?). I'm not sure...