### PR TITLE
Update Cargo metadata for 0.3.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auto_impl"
-version = "0.2.0"
+version = "0.3.0"
 authors = [
     "Ashley Mannix <ashleymannix@live.com.au>",
     "Lukas Kalbertodt <lukas.kalbertodt@gmail.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,16 +7,16 @@ authors = [
 ]
 license = "MIT/Apache-2.0"
 description = "Automatically implement traits for common smart pointers and closures"
-repository = "https://github.com/KodrAus/auto_impl"
+repository = "https://github.com/auto-impl-rs/auto_impl/"
 documentation = "https://docs.rs/auto_impl/"
-keywords = ["plugin"]
-categories = ["development-tools"]
+keywords = ["trait", "impl", "proc-macro", "closure"]
+categories = ["development-tools", "rust-patterns"]
 readme = "README.md"
 autotests = true
 edition = "2018"
 
 [badges]
-travis-ci = { repository = "KodrAus/auto_impl" }
+travis-ci = { repository = "auto-impl-rs/auto_impl" }
 
 
 [lib]


### PR DESCRIPTION
We almost did it! 

This PR only changes some metadata in `Cargo.toml` and bumps the version. I hope those changes are uncontroversial.

@KodrAus, if you give your OK, I would merge this and release this to crates.io. I don't want to wait for #44, because I have the feeling that PR might take some time to resolve still.