### PR TITLE
Update tests for upstream changes in rustc

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -139,22 +139,7 @@ fn eat_type(iter: &mut Peekable<token_stream::IntoIter>) -> Result<ProxyType, ()
 }
 
 
-#[cfg(test)]
-mod test {
-    use crate::proc_macro::TokenStream;
-
-    use super::parse_types;
-
-    #[test]
-    fn empty() {
-        assert_eq!(
-            parse_types(TokenStream::new()),
-            Ok(vec![])
-        );
-    }
-
-    // Right now, we can't really write useful tests. Many functions from
-    // `proc_macro` use a compiler internal session. This session is only valid
-    // when we were actually called as a proc macro. We need to add tests once
-    // this limitation of `proc_macro` is fixed.
-}
+// Right now, we can't really write useful tests. Many functions from
+// `proc_macro` use a compiler internal session. This session is only valid
+// when we were actually called as a proc macro. We need to add tests once
+// this limitation of `proc_macro` is fixed.

--- a/tests/compile-pass/trait_in_mods.rs
+++ b/tests/compile-pass/trait_in_mods.rs
@@ -1,13 +1,21 @@
 // Make sure that everything compiles even without the prelude. This basically
 // forces us to generate full paths for types of the standard/core library.
+// 
+// Note that `no_implicit_prelude` attribute appears to interact strangely
+// with Rust's 2018 style modules and extern crates.
 #![no_implicit_prelude]
+
+extern crate std;
+extern crate auto_impl;
 
 
 mod outer {
-    use auto_impl::auto_impl;
-    use std::{
-        string::String,
-        result::Result,
+    use crate::{
+        auto_impl::auto_impl,
+        std::{
+            string::String,
+            result::Result,
+        }
     };
 
     #[auto_impl(Fn)]
@@ -29,10 +37,12 @@ mod outer {
     }
 
     mod inner {
-        use auto_impl::auto_impl;
-        use std::{
-            string::String,
-            result::Result,
+        use crate::{
+            auto_impl::auto_impl,
+            std::{
+                string::String,
+                result::Result,
+            }
         };
 
         #[auto_impl(Fn)]


### PR DESCRIPTION
- It looks like the restrictions around calling proc-macro APIs outside of proc macros have been tightened, so our previous test no longer compiles.
- The `no_implicit_prelude` seems to interact strangely with 2018-style modules, but our generated code is ok.