### PR TITLE
Explicitly build on the latest stable in ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ matrix:
     - name: "Build on beta"
       rust: beta
       script: cargo build --verbose
+    - name: "Build on stable"
+      rust: stable
+      script: cargo build --verbose
 
 env:
   global:


### PR DESCRIPTION
Now that `1.31.0` is released we can build `auto_impl` on the stable channel :tada: