### PR TITLE
Adjust stderr files to new Rust error messages

### DIFF
--- a/tests/compile-fail/super_trait_not_implemented.stderr
+++ b/tests/compile-fail/super_trait_not_implemented.stderr
@@ -1,12 +1,10 @@
 error[E0277]: the trait bound `std::boxed::Box<Dog>: Supi` is not satisfied
-  --> $DIR/super_trait_not_implemented.rs:18:5
-   |
-18 |     requires_foo(Box::new(Dog)); // shouldn't, because `Box<Dog>: Supi` is not satisfied
-   |     ^^^^^^^^^^^^ the trait `Supi` is not implemented for `std::boxed::Box<Dog>`
-   |
-   = note: required because of the requirements on the impl of `Foo` for `std::boxed::Box<Dog>`
-note: required by `requires_foo`
-  --> $DIR/super_trait_not_implemented.rs:14:1
+  --> $DIR/super_trait_not_implemented.rs:18:18
    |
 14 | fn requires_foo<T: Foo>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |    ------------    --- required by this bound in `requires_foo`
+...
+18 |     requires_foo(Box::new(Dog)); // shouldn't, because `Box<Dog>: Supi` is not satisfied
+   |                  ^^^^^^^^^^^^^ the trait `Supi` is not implemented for `std::boxed::Box<Dog>`
+   |
+   = note: required because of the requirements on the impl of `Foo` for `std::boxed::Box<Dog>`

--- a/tests/compile-fail/trait_obj_value_self.stderr
+++ b/tests/compile-fail/trait_obj_value_self.stderr
@@ -1,14 +1,12 @@
 error[E0277]: the size for values of type `dyn Trait` cannot be known at compilation time
   --> $DIR/trait_obj_value_self.rs:12:5
    |
+9  | fn assert_impl<T: Trait>() {}
+   |    -----------    ----- required by this bound in `assert_impl`
+...
 12 |     assert_impl::<Box<dyn Trait>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `dyn Trait`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: required because of the requirements on the impl of `Trait` for `std::boxed::Box<dyn Trait>`
-note: required by `assert_impl`
-  --> $DIR/trait_obj_value_self.rs:9:1
-   |
-9  | fn assert_impl<T: Trait>() {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The Travis cronjob started failing. The error messages of the Rust compiler changed, this commit just updates those.