### PR TITLE
Only add trait (not lifetime) bounds from methods to `T` (and update tests)

### DIFF
--- a/src/gen.rs
+++ b/src/gen.rs
@@ -185,6 +185,19 @@ fn gen_header(
                         }
                     })
                     .flat_map(|p| &p.bounds)
+                    .filter_map(|b| {
+                        // We are only interested in trait bounds. That's
+                        // because lifetime bounds on `Self` do not need to be
+                        // added to the impl header. That's because all values
+                        // "derived" from `self` also meet the same lifetime
+                        // bound as `self`. In simpler terms: while `self.field`
+                        // might not be `Clone` even if `Self: Clone`,
+                        // `self.field` is always `: 'a` if `Self: 'a`.
+                        match b {
+                            TypeParamBound::Trait(t) => Some(t),
+                            TypeParamBound::Lifetime(_) => None,
+                        }
+                    })
             });
 
         // Determine if our proxy type needs a lifetime parameter

--- a/tests/compile-fail/attr_on_enum.stderr
+++ b/tests/compile-fail/attr_on_enum.stderr
@@ -7,3 +7,5 @@ error: couldn't parse trait item
   |
 4 | #[auto_impl(&, &mut)]
   | ^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile-fail/attr_on_fn.stderr
+++ b/tests/compile-fail/attr_on_fn.stderr
@@ -7,3 +7,5 @@ error: couldn't parse trait item
   |
 4 | #[auto_impl(&, &mut)]
   | ^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile-fail/attr_on_impl_block.stderr
+++ b/tests/compile-fail/attr_on_impl_block.stderr
@@ -7,3 +7,5 @@ error: couldn't parse trait item
   |
 6 | #[auto_impl(&, &mut)]
   | ^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile-fail/attr_on_struct.stderr
+++ b/tests/compile-fail/attr_on_struct.stderr
@@ -7,3 +7,5 @@ error: couldn't parse trait item
   |
 4 | #[auto_impl(&, &mut)]
   | ^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile-fail/attr_on_type.stderr
+++ b/tests/compile-fail/attr_on_type.stderr
@@ -7,3 +7,5 @@ error: couldn't parse trait item
   |
 4 | #[auto_impl(&, &mut)]
   | ^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile-fail/attr_on_unit_struct.stderr
+++ b/tests/compile-fail/attr_on_unit_struct.stderr
@@ -7,3 +7,5 @@ error: couldn't parse trait item
   |
 4 | #[auto_impl(&, &mut)]
   | ^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile-fail/super_trait_not_implemented.stderr
+++ b/tests/compile-fail/super_trait_not_implemented.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `std::boxed::Box<Dog>: Supi` is not satisfied
   --> $DIR/super_trait_not_implemented.rs:18:18
    |
 14 | fn requires_foo<T: Foo>(_: T) {}
-   |    ------------    --- required by this bound in `requires_foo`
+   |                    --- required by this bound in `requires_foo`
 ...
 18 |     requires_foo(Box::new(Dog)); // shouldn't, because `Box<Dog>: Supi` is not satisfied
    |                  ^^^^^^^^^^^^^ the trait `Supi` is not implemented for `std::boxed::Box<Dog>`

--- a/tests/compile-fail/trait_obj_value_self.stderr
+++ b/tests/compile-fail/trait_obj_value_self.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `dyn Trait` cannot be known at compila
   --> $DIR/trait_obj_value_self.rs:12:5
    |
 9  | fn assert_impl<T: Trait>() {}
-   |    -----------    ----- required by this bound in `assert_impl`
+   |                   ----- required by this bound in `assert_impl`
 ...
 12 |     assert_impl::<Box<dyn Trait>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time


### PR DESCRIPTION
Fixes #65