### PR TITLE
Better error messages

### DIFF
--- a/src/gen.rs
+++ b/src/gen.rs
@@ -341,6 +341,24 @@ fn gen_fn_type_for_trait(proxy_type: &ProxyType, trait_def: &ItemTrait) -> Token
         );
     }
 
+    // Function traits cannot support generics in their arguments
+    // These would require HRTB for types instead of just lifetimes
+    for type_param in sig.generics.type_params() {
+        emit_error!(
+            type_param.span(),
+            "the trait '{}' cannot be implemented for Fn-traits: generic arguments are not allowed",
+            trait_def.ident,
+        );
+    }
+
+    for const_param in sig.generics.const_params() {
+        emit_error!(
+            const_param.span(),
+            "the trait '{}' cannot be implemented for Fn-traits: constant arguments are not allowed",
+            trait_def.ident,
+        );
+    }
+
     // =======================================================================
     // Check if the trait can be implemented for the given proxy type
     let self_type = SelfType::from_sig(sig);

--- a/tests/compile-fail/fn_const_generics.rs
+++ b/tests/compile-fail/fn_const_generics.rs
@@ -1,0 +1,10 @@
+use auto_impl::auto_impl;
+
+
+#[auto_impl(Fn)]
+trait Greeter {
+    fn greet<const N: usize>(&self, id: usize);
+}
+
+
+fn main() {}

--- a/tests/compile-fail/fn_const_generics.stderr
+++ b/tests/compile-fail/fn_const_generics.stderr
@@ -1,0 +1,5 @@
+error: the trait 'Greeter' cannot be implemented for Fn-traits: constant arguments are not allowed
+ --> tests/compile-fail/fn_const_generics.rs:6:14
+  |
+6 |     fn greet<const N: usize>(&self, id: usize);
+  |              ^^^^^

--- a/tests/compile-fail/fn_generics.rs
+++ b/tests/compile-fail/fn_generics.rs
@@ -1,0 +1,11 @@
+use std::fmt::Display;
+use auto_impl::auto_impl;
+
+
+#[auto_impl(Fn)]
+trait Greeter {
+    fn greet<T: Display>(&self, name: T);
+}
+
+
+fn main() {}

--- a/tests/compile-fail/fn_generics.stderr
+++ b/tests/compile-fail/fn_generics.stderr
@@ -1,0 +1,5 @@
+error: the trait 'Greeter' cannot be implemented for Fn-traits: generic arguments are not allowed
+ --> tests/compile-fail/fn_generics.rs:7:14
+  |
+7 |     fn greet<T: Display>(&self, name: T);
+  |              ^


### PR DESCRIPTION
Closes #37 

Instead of actually making this work, it instead makes the error messages a little clearer when attempting to implement `Fn` for traits that would require some kind of `for<T: Trait> Fn(T)` syntax.