### PR TITLE
Change the encoding of supertrait clauses to support associated types

### DIFF
--- a/src/gen.rs
+++ b/src/gen.rs
@@ -270,7 +270,7 @@ fn gen_header(
 
         if !trait_def.supertraits.is_empty() {
             let supertraits = &trait_def.supertraits;
-            out.extend(quote! { #self_ty: #supertraits, });
+            out.extend(quote! { #proxy_ty_param: #supertraits, });
         }
         if let Some(predicates) = where_clause.map(|c| &c.predicates) {
             out.extend(predicates.into_token_stream());

--- a/tests/compile-fail/super_trait_not_implemented.stderr
+++ b/tests/compile-fail/super_trait_not_implemented.stderr
@@ -1,22 +1,27 @@
-error[E0277]: the trait bound `Box<Dog>: Supi` is not satisfied
-  --> tests/compile-fail/super_trait_not_implemented.rs:18:18
-   |
-18 |     requires_foo(Box::new(Dog)); // shouldn't, because `Box<Dog>: Supi` is not satisfied
-   |     ------------ ^^^^^^^^^^^^^ the trait `Supi` is not implemented for `Box<Dog>`
-   |     |
-   |     required by a bound introduced by this call
-   |
-   = help: the trait `Supi` is implemented for `Dog`
-note: required for `Box<Dog>` to implement `Foo`
-  --> tests/compile-fail/super_trait_not_implemented.rs:5:1
-   |
-5  | #[auto_impl(Box, &)]
-   | ^^^^^^^^^^^^^^^^^^^^
-6  | trait Foo: Supi {}
-   |       ^^^  ---- unsatisfied trait bound introduced here
-note: required by a bound in `requires_foo`
-  --> tests/compile-fail/super_trait_not_implemented.rs:14:20
-   |
-14 | fn requires_foo<T: Foo>(_: T) {}
-   |                    ^^^ required by this bound in `requires_foo`
-   = note: this error originates in the attribute macro `auto_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
+error[E0277]: the trait bound `Box<T>: Supi` is not satisfied
+ --> tests/compile-fail/super_trait_not_implemented.rs:5:1
+  |
+5 | #[auto_impl(Box, &)]
+  | ^^^^^^^^^^^^^^^^^^^^ the trait `Supi` is not implemented for `Box<T>`
+  |
+  = help: the trait `Supi` is implemented for `Dog`
+note: required by a bound in `Foo`
+ --> tests/compile-fail/super_trait_not_implemented.rs:6:12
+  |
+6 | trait Foo: Supi {}
+  |            ^^^^ required by this bound in `Foo`
+  = note: this error originates in the attribute macro `auto_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `&'a T: Supi` is not satisfied
+ --> tests/compile-fail/super_trait_not_implemented.rs:5:1
+  |
+5 | #[auto_impl(Box, &)]
+  | ^^^^^^^^^^^^^^^^^^^^ the trait `Supi` is not implemented for `&'a T`
+  |
+  = help: the trait `Supi` is implemented for `Dog`
+note: required by a bound in `Foo`
+ --> tests/compile-fail/super_trait_not_implemented.rs:6:12
+  |
+6 | trait Foo: Supi {}
+  |            ^^^^ required by this bound in `Foo`
+  = note: this error originates in the attribute macro `auto_impl` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile-pass/super_trait_associated_type.rs
+++ b/tests/compile-pass/super_trait_associated_type.rs
@@ -1,0 +1,14 @@
+use auto_impl::auto_impl;
+
+#[auto_impl(Box, &)]
+trait Supi {
+    type Assoc;
+}
+
+#[auto_impl(Box, &)]
+trait Foo: Supi {
+    fn foo(&self, x: Self::Assoc) -> String;
+}
+
+
+fn main() {}

--- a/tests/compile-pass/super_trait_complex_for_refs.rs
+++ b/tests/compile-pass/super_trait_complex_for_refs.rs
@@ -1,5 +1,6 @@
 use auto_impl::auto_impl;
 
+#[auto_impl(Box, &)]
 trait Supi<'a, T> {
     fn supi(&self);
 }

--- a/tests/compile-pass/super_trait_simple_for_refs.rs
+++ b/tests/compile-pass/super_trait_simple_for_refs.rs
@@ -1,5 +1,6 @@
 use auto_impl::auto_impl;
 
+#[auto_impl(Box, &)]
 trait Supi {}
 
 #[auto_impl(Box, &)]


### PR DESCRIPTION
This pull request is related to the discussion in #87.

When `auto_impl` is used to implement trait that has a supertrait, it needs to enforce that the inner type already implements the supertrait. However, the current encoding does not work correctly when the supertrait has an associated type that the subtrait refers to in one of its methods.

To make this concrete, take the following example.

```rust
use auto_impl::auto_impl;

pub trait Foo {
    type MyType;
}

pub trait Bar: Foo {
    fn bar(&self, value: Self::MyType);
}
```

`auto_impl` will expand this code into the following, which fails to compile since the compiler doesn't know that `Arc<T>::Foo` is the same type as `T::Foo`.

```rust
pub trait Foo {
    type MyType;
}

pub trait Bar: Foo {
    fn bar(&self, value: Self::MyType);
}

const _: () = {
    extern crate alloc;
    impl<T: Bar + ?Sized> Bar for alloc::sync::Arc<T>
    where
        alloc::sync::Arc<T>: Foo,
    {
        fn bar(&self, value: Self::MyType) {
            T::bar(self, value)
        }
    }
};
```

This commit changes how `auto_impl` encodes supertrait `where` constraints like `alloc::sync::Arc<T>: Foo` to refer to the inner type parameter instead, e.g., `T: Foo`. With this change, if we also annotate trait `Foo` with `auto_impl`, then the associated type example will compile, because the compiler has access to the implementation of `Foo` for `Arc<T>` when `T: Foo`:

```rust
use auto_impl::auto_impl;

pub trait Foo {
    type MyType;
}

pub trait Bar: Foo {
    fn bar(&self, value: Self::MyType);
}
```

This change is _not_ backwards compatible in certain edge scenarios. For example, the new encoding does not permit using `auto_impl` to implement `Bar` for `Arc<T>` but having a user-defined / custom implementation of `Arc<T>` for its supertrait `Foo`.

It also causes `auto_impl` on `Bar` to fail to compile _eagerly_ when there is no corresponding implementation of `Foo`, whereas the previous behavior would allow this to compile (but would produce a constraint that fails to be satisfied if the implementation of `Bar` is ever attempted to be used).

These seem like niche scenarios, but this does constitute a functional (though minor) change. However, this this trade-off may be worth since it's otherwise not possible to use associated types from supertraits with `auto_impl`.

This commit also updates the unit tests accordingly; for example, adding `auto_impl` on supertraits where it was missing before in order to fix the new build errors.