### PR TITLE
Add support for GATs with trait bounds and where clauses

### DIFF
--- a/src/gen.rs
+++ b/src/gen.rs
@@ -609,10 +609,10 @@ fn gen_type_item(
     // We simply use the associated type from our type parameter.
     let assoc_name = &item.ident;
     let attrs = filter_attrs(&item.attrs);
-    let generics = &item.generics;
+    let (impl_generics, type_generics, where_clause) = item.generics.split_for_impl();
 
     Ok(quote! {
-        #(#attrs)* type #assoc_name #generics = #proxy_ty_param::#assoc_name #generics;
+        #(#attrs)* type #assoc_name #impl_generics = #proxy_ty_param::#assoc_name #type_generics #where_clause;
     })
 }
 

--- a/tests/compile-pass/associated_type_with_where_clause_for_all_refs.rs
+++ b/tests/compile-pass/associated_type_with_where_clause_for_all_refs.rs
@@ -1,0 +1,22 @@
+use auto_impl::auto_impl;
+
+#[auto_impl(Arc, Box, Rc, &, &mut)]
+trait HasAssociatedTypeWithBounds {
+    type AssociatedType<'a, T: From<usize> + 'a>;
+}
+
+#[auto_impl(Arc, Box, Rc, &, &mut)]
+trait HasAssociatedTypeWithBoundsAndWhereClause {
+    type AssociatedType<'a, T>
+    where
+        T: From<usize> + 'a;
+}
+
+#[auto_impl(Arc, Box, Rc, &, &mut)]
+trait HasAssociatedTypeWithRedundantBoundsAndWhereClause {
+    type AssociatedType<'a, T: From<usize> + 'a>
+    where
+        T: From<usize> + 'a;
+}
+
+fn main() {}


### PR DESCRIPTION
Hey! First of all great crate and lovely code - it's been a breeze figuring this out.

Currently the following code:

```rust
#[auto_impl(Arc, Box, Rc, &, &mut)]
trait HasAssociatedTypeWithBoundsAndWhereClause {
    type AssociatedType<'a, T>
    where
        T: From<usize> + 'a;
}
```

fails to compile because the macro doesn't generate the correct trait bounds and/or where clause on the associated type.

This PR fixes it by splitting the generics of an `TraitItemType` with `Generics::split_for_impl` - doesn't affect any other cases.